### PR TITLE
Add metadata extraction support

### DIFF
--- a/internal/crawler/api.go
+++ b/internal/crawler/api.go
@@ -39,7 +39,7 @@ func GenerateEmbeddings() ([][]float64, error) {
 	}
 
 	resp, err := http.Post(
-		"http://localhost:8000/embed",
+		"http://localhost:8080/embed",
 		"application/json",
 		&buf,
 	)

--- a/internal/crawler/crawler2.go
+++ b/internal/crawler/crawler2.go
@@ -68,6 +68,7 @@ func (m *Manager) FindLinks() []WebNode {
 	//3. chose top 5 seeds using cosine similarity
 	JobQueue := relevantURLs[minusTen:length]
 	//relevant seeds have been found
+	fmt.Println("JobQueue: ", JobQueue)
 	fmt.Println("Number of relevant URLs: ", len(relevantURLs))
 	for _, node := range relevantURLs {
 		fmt.Println("	closest-match URL: ", node.Url, node.context.Description)

--- a/internal/crawler/crawler2.go
+++ b/internal/crawler/crawler2.go
@@ -25,7 +25,7 @@ func (m *Manager) FindLinks() []WebNode {
 	}
 
 	resp, err := http.Post(
-		"http://localhost:8000/embed",
+		"http://localhost:8080/embed",
 		"application/json",
 		&buf,
 	)
@@ -158,7 +158,7 @@ func (m *Manager) Extract2(node *WebNode) ([]WebNode, error) {
 		return nil, fmt.Errorf("parsing %s as HTML: %v", node.Url, err)
 	}
 
-	VisitNode(doc, &m.downloadURLs, resp, node)
+	VisitNode(doc, &m.downloadURLs, resp, node, doc)
 
 	return links, nil
 }

--- a/internal/crawler/data.go
+++ b/internal/crawler/data.go
@@ -30,6 +30,21 @@ var GeoMIMETypes = map[string]bool{
 	"application/topo+json":                true,
 }
 
+// GeoFileExtensions lists common geospatial dataset file extensions.
+var GeoFileExtensions = map[string]bool{
+	".zip":     true,
+	".csv":     true,
+	".json":    true,
+	".geojson": true,
+	".kml":     true,
+	".kmz":     true,
+	".tif":     true,
+	".tiff":    true,
+	".nc":      true,
+	".grib":    true,
+	".xml":     true,
+}
+
 var UnwantedClassOrIDSubstrings = map[string]bool{
 	// Navigation, headers, menus
 	"nav":        true,

--- a/internal/crawler/metadata.go
+++ b/internal/crawler/metadata.go
@@ -1,0 +1,139 @@
+package crawler
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// downloadMetadata represents extracted information about a downloadable file.
+type downloadMetadata struct {
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Keywords    []string `json:"keywords,omitempty"`
+	URL         string   `json:"url"`
+}
+
+// ExtractMetadata parses metadata from the provided HTML document and returns a
+// JSON string describing the download URL and page details.
+func ExtractMetadata(doc *html.Node, pageURL, downloadURL string) string {
+	md := downloadMetadata{URL: downloadURL}
+	var xmlLinks []string
+
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			switch n.Data {
+			case "title":
+				if md.Title == "" && n.FirstChild != nil {
+					md.Title = strings.TrimSpace(n.FirstChild.Data)
+				}
+			case "meta":
+				var name, property, content string
+				for _, a := range n.Attr {
+					switch strings.ToLower(a.Key) {
+					case "name":
+						name = strings.ToLower(a.Val)
+					case "property":
+						property = strings.ToLower(a.Val)
+					case "content":
+						content = a.Val
+					}
+				}
+				key := name
+				if key == "" {
+					key = property
+				}
+				switch key {
+				case "description", "og:description":
+					if md.Description == "" {
+						md.Description = content
+					}
+				case "keywords":
+					if len(md.Keywords) == 0 && content != "" {
+						parts := strings.Split(content, ",")
+						for i, p := range parts {
+							parts[i] = strings.TrimSpace(p)
+						}
+						md.Keywords = parts
+					}
+				case "og:title":
+					if md.Title == "" {
+						md.Title = content
+					}
+				}
+			case "script":
+				var typ string
+				for _, a := range n.Attr {
+					if strings.ToLower(a.Key) == "type" {
+						typ = strings.ToLower(a.Val)
+					}
+				}
+				if strings.Contains(typ, "ld+json") && n.FirstChild != nil {
+					var data map[string]interface{}
+					if err := json.Unmarshal([]byte(n.FirstChild.Data), &data); err == nil {
+						if d, ok := data["description"].(string); ok && md.Description == "" {
+							md.Description = d
+						}
+						if t, ok := data["name"].(string); ok && md.Title == "" {
+							md.Title = t
+						}
+					}
+				}
+			case "link":
+				var href, typ string
+				for _, a := range n.Attr {
+					if a.Key == "href" {
+						href = a.Val
+					} else if a.Key == "type" {
+						typ = strings.ToLower(a.Val)
+					}
+				}
+				if strings.Contains(typ, "xml") {
+					xmlLinks = append(xmlLinks, href)
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+
+	base, _ := url.Parse(pageURL)
+	for _, l := range xmlLinks {
+		u, err := base.Parse(l)
+		if err != nil {
+			continue
+		}
+		resp, err := http.Get(u.String())
+		if err != nil {
+			continue
+		}
+		data, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			continue
+		}
+		var x struct {
+			Title       string `xml:"title"`
+			Description string `xml:"description"`
+		}
+		if err := xml.Unmarshal(data, &x); err == nil {
+			if md.Title == "" {
+				md.Title = strings.TrimSpace(x.Title)
+			}
+			if md.Description == "" {
+				md.Description = strings.TrimSpace(x.Description)
+			}
+		}
+	}
+
+	b, _ := json.Marshal(md)
+	return string(b)
+}

--- a/internal/crawler/metadata_test.go
+++ b/internal/crawler/metadata_test.go
@@ -1,0 +1,41 @@
+package crawler
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+type testMeta struct {
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Keywords    []string `json:"keywords,omitempty"`
+	URL         string   `json:"url"`
+}
+
+func TestExtractMetadata(t *testing.T) {
+	htmlStr := `<html><head><title>Dataset</title><meta name="description" content="some data"><meta name="keywords" content="geo,data"></head><body></body></html>`
+	doc, err := html.Parse(strings.NewReader(htmlStr))
+	if err != nil {
+		t.Fatalf("parse html: %v", err)
+	}
+	res := ExtractMetadata(doc, "http://example.com/page", "http://example.com/file.zip")
+	var md testMeta
+	if err := json.Unmarshal([]byte(res), &md); err != nil {
+		t.Fatalf("unmarshal json: %v", err)
+	}
+	if md.Title != "Dataset" {
+		t.Errorf("title mismatch: %s", md.Title)
+	}
+	if md.Description != "some data" {
+		t.Errorf("description mismatch: %s", md.Description)
+	}
+	if len(md.Keywords) != 2 || md.Keywords[0] != "geo" || md.Keywords[1] != "data" {
+		t.Errorf("keywords mismatch: %v", md.Keywords)
+	}
+	if md.URL != "http://example.com/file.zip" {
+		t.Errorf("url mismatch: %s", md.URL)
+	}
+}


### PR DESCRIPTION
## Summary
- add `ExtractMetadata` helper to gather metadata from page
- hook metadata extraction into `VisitNode` when encountering downloadable file links
- track file extensions of interest
- use vector server on port 8080
- test metadata extraction

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68791e2e0490832cb25a8c9523b69958