### PR TITLE
Refactor cached embedding storage

### DIFF
--- a/internal/crawler/api.go
+++ b/internal/crawler/api.go
@@ -88,7 +88,7 @@ func GenerateEmbeddings() ([][]float64, error) {
 func (m *Manager) Init() {
 	data := make(map[string]DataContext)
 	//data is a map of URL : embedding
-	// m.CachedURLEmbeddings = data
+	// m.CachedURLEmbeddings.Map = data
 
 	//data SHOULD BE a map of URL: DataContext{Description, Embedding}
 
@@ -109,7 +109,7 @@ func (m *Manager) Init() {
 			counter++
 		}
 		WriteToGob(dataPath, data)
-		m.CachedURLEmbeddings = data
+		m.CachedURLEmbeddings.Map = data
 		return
 	}
 	//read searchFrom .gob file
@@ -122,7 +122,7 @@ func (m *Manager) Init() {
 	if err := decoder.Decode(&data); err != nil {
 		log.Fatalf("An error occured while decoding .gob file to cache: %v", err)
 	}
-	m.CachedURLEmbeddings = data
+	m.CachedURLEmbeddings.Map = data
 	log.Println("Cached URL-embeddings loaded")
 }
 
@@ -134,14 +134,14 @@ func (m *Manager) Close(newURLs []WebNode) {
 		wg.Add(1)
 		go func(newNode WebNode) {
 			seen := false
-			for cachedURL, _ := range m.CachedURLEmbeddings {
+			for cachedURL := range m.CachedURLEmbeddings.Map {
 				if cachedURL == newNode.Url {
 					seen = true
 				}
 			}
 			if seen == false {
 				mu.Lock()
-				m.CachedURLEmbeddings[newNode.Url] = newNode.context
+				m.CachedURLEmbeddings.Map[newNode.Url] = newNode.context
 				mu.Unlock()
 			}
 			wg.Done()
@@ -149,7 +149,7 @@ func (m *Manager) Close(newURLs []WebNode) {
 	}
 	wg.Wait()
 	//write to .gob file:
-	WriteToGob(dataPath, m.CachedURLEmbeddings)
+	WriteToGob(dataPath, m.CachedURLEmbeddings.Map)
 }
 
 // Run executes the CLI application.

--- a/internal/crawler/crawler2.go
+++ b/internal/crawler/crawler2.go
@@ -46,7 +46,7 @@ func (m *Manager) FindLinks() []WebNode {
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	for url, ctx := range m.CachedURLEmbeddings {
+	for url, ctx := range m.CachedURLEmbeddings.Map {
 		wg.Add(1)
 		go func(context DataContext, url string) {
 			score, err := Cosine(queryEmbedding, context.Embedding)

--- a/internal/crawler/structs.go
+++ b/internal/crawler/structs.go
@@ -20,7 +20,7 @@ type Manager struct {
 	downloadPath        *string
 	searchQuery         *string
 	downloadURLs        []WebNode
-	CachedURLEmbeddings map[string]DataContext
+	CachedURLEmbeddings ConcurrentSafeMap
 	searchFrom          map[string]DataContext
 	linkChan            chan struct{}
 	smTokens            chan struct{}


### PR DESCRIPTION
## Summary
- make Manager use `ConcurrentSafeMap` for `CachedURLEmbeddings`
- update initialization and usage of `CachedURLEmbeddings` to use the `Map` field

## Testing
- `go test ./...` *(fails: connection refused for embedding service)*

------
https://chatgpt.com/codex/tasks/task_e_687a92b15248832caedc8af8adc8829d