### PR TITLE
Add explanatory comments

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,8 @@ package main
 
 import "geospatial-web-scraper/internal/crawler"
 
+// main is the entry point for the command line tool. It delegates all work to
+// the crawler package.
 func main() {
 	crawler.Run()
 }

--- a/internal/crawler/api.go
+++ b/internal/crawler/api.go
@@ -16,6 +16,9 @@ import (
 var dataPath = "/Users/thorbthorb/Downloads/geospatial-web-scraper/data.gob"
 var findLinksLogPath = "/Users/thorbthorb/Downloads/geospatial-web-scraper/logs/findLinks.log"
 
+// GetBatchedEmbeddings sends a slice of strings to the local embedding service
+// and returns the resulting embeddings. The function performs a single HTTP
+// POST request with the provided texts and decodes the JSON response.
 func GetBatchedEmbeddings(texts []string) (EmbeddingResponse, error) {
 	var buf bytes.Buffer
 	newPayload := TextPayload{Texts: texts}
@@ -41,6 +44,9 @@ func GetBatchedEmbeddings(texts []string) (EmbeddingResponse, error) {
 	return res, nil
 }
 
+// WriteToLog opens or creates the specified log file and sets the logger output
+// to this file. It returns the opened *os.File so the caller can close it when
+// finished.
 func WriteToLog(filepath string) (*os.File, error) {
 	logFile, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -50,6 +56,9 @@ func WriteToLog(filepath string) (*os.File, error) {
 	return logFile, nil
 }
 
+// WriteToGob serializes the provided data value to a gob file at the given
+// path. Existing data is appended to, allowing the cache to persist between
+// runs.
 func WriteToGob(filepath string, data interface{}) error {
 	file, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -65,6 +74,8 @@ func WriteToGob(filepath string, data interface{}) error {
 
 }
 
+// GenerateEmbeddings reads all seed descriptions, sends them for embedding, and
+// returns the embeddings in the same order as the seeds.
 func GenerateEmbeddings() ([][]float64, error) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
@@ -104,6 +115,10 @@ func GenerateEmbeddings() ([][]float64, error) {
 	return res.Embeddings, nil
 }
 
+// Init prepares the Manager by loading or creating the embedding cache stored
+// on disk. If no cache exists, all seed URLs are embedded and written to the
+// gob file. Loaded or generated embeddings are stored in
+// m.CachedURLEmbeddings.
 func (m *Manager) Init() {
 	data := make(map[string]DataContext)
 	//data is a map of URL : embedding

--- a/internal/crawler/methods.go
+++ b/internal/crawler/methods.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 )
 
+// Contains returns the index of value in slice, ignoring case. If the value is
+// not present it returns -1.
 func Contains(value string, slice []string) int {
 	for idx, wrd := range slice {
 		if strings.Compare(strings.ToLower(wrd), strings.ToLower(value)) == 0 {
@@ -17,6 +19,8 @@ func Contains(value string, slice []string) int {
 	return -1
 }
 
+// MergeSort sorts the slice of WebNodes in place by CosineSimilarity using a
+// classic recursive merge sort algorithm.
 func MergeSort(list *[]WebNode, start int, end int) []WebNode {
 	if end-start <= 1 {
 		return (*list)[start:end]
@@ -30,6 +34,8 @@ func MergeSort(list *[]WebNode, start int, end int) []WebNode {
 	return Merge(&left, &right)
 }
 
+// Merge merges two already sorted WebNode slices by CosineSimilarity and
+// returns the combined sorted slice.
 func Merge(a *[]WebNode, b *[]WebNode) []WebNode {
 	result := make([]WebNode, 0, len(*a)+len(*b))
 	i, j := 0, 0

--- a/internal/crawler/structs.go
+++ b/internal/crawler/structs.go
@@ -52,6 +52,9 @@ type EmbeddingResponse struct {
 // map[string] Cache
 
 // Cache will have Cache{Embedding []float64, Description string, filepath string}
+// SlicesEqualUnordered compares two string slices regardless of element order.
+// It returns true when both slices contain the same elements with the same
+// multiplicities.
 func SlicesEqualUnordered(a, b []string) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Summary
- document exported functions in `api.go`
- add doc comments in crawler files
- describe helper methods
- note main entry point

## Testing
- `go test ./...` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687c7887ea00832c9200f03449091d27