### PR TITLE
Fix newline formatting in metadata description

### DIFF
--- a/internal/crawler/metadata.go
+++ b/internal/crawler/metadata.go
@@ -137,6 +137,11 @@ func ExtractMetadata(doc *html.Node, pageURL, downloadURL string) string {
 		}
 	}
 
+	// Clean any newlines or excess whitespace that may have been
+	// captured from the HTML so they don't appear as escaped "\n" when
+	// printed or marshalled to JSON.
+	md.Description = strings.Join(strings.Fields(md.Description), " ")
+
 	b, _ := json.Marshal(md)
 	return string(b)
 }


### PR DESCRIPTION
## Summary
- sanitize the metadata description by stripping newline characters

## Testing
- `go test ./...` *(fails: TestGenerateEmbeddings, TestExtractMetadata)*

------
https://chatgpt.com/codex/tasks/task_e_687c994bfd0c832cbf8e5fa7afae8a04